### PR TITLE
 Change gzip to not include mtime

### DIFF
--- a/crosswalk/build_players_exports.py
+++ b/crosswalk/build_players_exports.py
@@ -21,8 +21,9 @@ def load_fields(core_schema_path, source_schema_path):
 
 def gzip_compress(input_file):
     with open(input_file, 'rb') as f_in:
-        with gzip.open(Path(input_file.parent) / (input_file.name + ".gz"), 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
+        with open(Path(input_file.parent) / (input_file.name + ".gz"), 'wb') as f_out:
+            with gzip.GzipFile(fileobj=f_out, mode='wb', mtime=0) as gz:
+                shutil.copyfileobj(f_in, gz)
 
 def load_csv(filepath):
     with open(filepath, newline='', encoding='utf-8') as f:


### PR DESCRIPTION
Currently the gzip headers include the time file was compressed, resulting in non-reproducible builds (and causing a commit even when the underlying files aren't changed). Change the gzip operation to not include modified time.