### PR TITLE
Scripts shouldn't return non-zero exit code if in 'issues' mode

### DIFF
--- a/crosswalk/check_missing_mlb_rostered.py
+++ b/crosswalk/check_missing_mlb_rostered.py
@@ -163,7 +163,8 @@ def main(args):
         print(f"⚠️ Missing {len(skeletons)} rostered players")
         if args.issues_file:
             write_issues_txt(skeletons, args.issues_file)
-        sys.exit(1)
+        else:
+            sys.exit(1)
     else:
         print("✅ No missing players from rosters")
 

--- a/crosswalk/validate_fg_ids.py
+++ b/crosswalk/validate_fg_ids.py
@@ -120,7 +120,8 @@ def validate_csv(
             print(f"{len(issues)} changed IDs found")
         if issues_file:
             write_issues_txt(issues, issues_file)
-        sys.exit(1)
+        else:
+            sys.exit(1)
     else:
         print("No redirecting Fangraphs IDs found")
 


### PR DESCRIPTION
For our workflow-intended scripts, don't return non-zero if we're creating issues files for github workflow actions.